### PR TITLE
Removed unused variable assignation

### DIFF
--- a/ApiGatewayAuthExtension.js
+++ b/ApiGatewayAuthExtension.js
@@ -42,7 +42,6 @@ class ApiGatewayAuthExtension {
 	_compileEvents() {
 		const tmp = this.serverless.service.provider.compiledCloudFormationTemplate;
 		const resources = tmp.Resources;
-		const iamFunctions = this.serverless.service.custom.useApiGatewayIAMAuthForLambdaFunctions;
 
 		this.serverless.service.getAllFunctions().forEach((functionName) => {
 			const functionObject = this.serverless.service.functions[functionName];


### PR DESCRIPTION
This variable is not used and will raise an exception if `this.serverless.service.custom.useApiGatewayIAMAuthForLambdaFunctions;` is not set.