### PR TITLE
Add description of the built in method

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,21 @@ Serverless plugin supporting AWS_IAM authorizer on API Gateway method
 
 Adds the ability to configure AWS_IAM for your API Gateway endpoints, and "Invoke with caller credentials"
 
+# Note
+
+Since serverless version 1.14.0 it's been possible to add `authorizer: aws_iam` as a part of the http event configuration. Example:
+
+```yml
+  companies:
+    handler: src/companies.main
+    events:
+      - http:
+          path: companies
+          method: get
+          authorizer: aws_iam
+
+```
+
 ## Usage
 register plugin:
 ```YAML


### PR DESCRIPTION
Since this is now supported in serverless itself, this module should recommend using the native parameter instead. IMO.